### PR TITLE
refactor(pmtud): implement Copy for Probe

### DIFF
--- a/neqo-transport/src/pmtud.rs
+++ b/neqo-transport/src/pmtud.rs
@@ -29,7 +29,7 @@ const MTU_SIZES_V6: &[usize] = &[
 const MAX_PROBES: usize = 3;
 const PMTU_RAISE_TIMER: Duration = Duration::from_secs(600);
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 enum Probe {
     NotNeeded,
     Needed,
@@ -138,7 +138,7 @@ impl Pmtud {
     /// Allows filtering packets without holding a reference to [`Pmtud`]. When
     /// in doubt, use [`Pmtud::is_probe`].
     pub fn is_probe_filter(&self) -> impl Fn(&SentPacket) -> bool {
-        let probe_state = self.probe_state.clone();
+        let probe_state = self.probe_state;
         let probe_size = self.probe_size();
 
         move |p: &SentPacket| -> bool { probe_state == Probe::Sent && p.len() == probe_size }


### PR DESCRIPTION
Nit pick: 

`Probe` is a small simple enum on the stack, thus convention is to implement `Copy` instead of only `Clone` with a call to `clone()`.

The following helped me in the past:

> When should my type be Copy?
>
> Generally speaking, if your type can implement Copy, it should. Keep in mind,
> though, that implementing Copy is part of the public API of your type. If the
> type might become non-Copy in the future, it could be prudent to omit the Copy
> implementation now, to avoid a breaking API change.

https://doc.rust-lang.org/std/marker/trait.Copy.html#when-should-my-type-be-copy