### PR TITLE
Add some helper functions for headers

### DIFF
--- a/neqo-bin/src/server/http3.rs
+++ b/neqo-bin/src/server/http3.rs
@@ -12,7 +12,7 @@ use std::{
     time::Instant,
 };
 
-use neqo_common::{hex, qdebug, qerror, qinfo, Datagram, Header};
+use neqo_common::{header::HeadersExt, hex, qdebug, qerror, qinfo, Datagram, Header};
 use neqo_crypto::{generate_ech_keys, random, AntiReplay};
 use neqo_http3::{
     Http3OrWebTransportStream, Http3Parameters, Http3Server, Http3ServerEvent, StreamId,
@@ -94,12 +94,12 @@ impl super::HttpServer for HttpServer {
                 } => {
                     qdebug!("Headers (request={stream} fin={fin}): {headers:?}");
 
-                    if headers.contains(&Header::new(":method", "POST")) {
+                    if headers.contains_header(":method", "POST") {
                         self.posts.insert(stream, 0);
                         continue;
                     }
 
-                    let Some(path) = headers.iter().find(|&h| h.name() == ":path") else {
+                    let Some(path) = headers.find_header(":path") else {
                         stream
                             .cancel_fetch(neqo_http3::Error::HttpRequestIncomplete.code())
                             .unwrap();

--- a/neqo-common/src/header.rs
+++ b/neqo-common/src/header.rs
@@ -46,3 +46,29 @@ impl Header {
         &self.value
     }
 }
+
+impl<T: AsRef<str>, U: AsRef<str>> PartialEq<(T, U)> for Header {
+    fn eq(&self, other: &(T, U)) -> bool {
+        self.name == other.0.as_ref() && self.value == other.1.as_ref()
+    }
+}
+
+pub trait HeadersExt<'h> {
+    fn contains_header<T: AsRef<str>, U: AsRef<str>>(self, name: T, value: U) -> bool;
+    fn find_header<T: AsRef<str> + 'h>(self, name: T) -> Option<&'h Header>;
+}
+
+impl<'h, H> HeadersExt<'h> for H
+where
+    H: IntoIterator<Item = &'h Header> + 'h,
+{
+    fn contains_header<T: AsRef<str>, U: AsRef<str>>(self, name: T, value: U) -> bool {
+        let (name, value) = (name.as_ref(), value.as_ref());
+        self.into_iter().any(|h| h == &(name, value))
+    }
+
+    fn find_header<T: AsRef<str> + 'h>(self, name: T) -> Option<&'h Header> {
+        let name = name.as_ref();
+        self.into_iter().find(|h| h.name == name)
+    }
+}

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/mod.rs
@@ -10,7 +10,7 @@ mod sessions;
 mod streams;
 use std::{cell::RefCell, rc::Rc, time::Duration};
 
-use neqo_common::event::Provider;
+use neqo_common::{event::Provider, header::HeadersExt};
 use neqo_crypto::AuthenticationStatus;
 use neqo_transport::{ConnectionParameters, Pmtud, StreamId, StreamType};
 use test_fixture::{
@@ -62,8 +62,8 @@ pub fn default_http3_server(server_params: Http3Parameters) -> Http3Server {
 
 pub fn assert_wt(headers: &[Header]) {
     assert!(
-        headers.contains(&Header::new(":method", "CONNECT"))
-            && headers.contains(&Header::new(":protocol", "webtransport"))
+        headers.contains_header(":method", "CONNECT")
+            && headers.contains_header(":protocol", "webtransport")
     );
 }
 
@@ -183,7 +183,7 @@ impl WtTest {
                 }) if (
                     stream_id == wt_session_id &&
                     status == 200 &&
-                    headers.contains(&Header::new(":status", "200"))
+                    headers.contains_header(":status", "200")
                 )
             )
         };

--- a/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
+++ b/neqo-http3/src/features/extended_connect/tests/webtransport/sessions.rs
@@ -6,7 +6,7 @@
 
 use std::mem;
 
-use neqo_common::{event::Provider, Encoder};
+use neqo_common::{event::Provider, header::HeadersExt, Encoder};
 use neqo_transport::StreamType;
 use test_fixture::now;
 
@@ -161,7 +161,7 @@ fn wt_session_response_with_1xx() {
             }) if (
                 stream_id == wt_session_id &&
                 status == 200 &&
-                headers.contains(&Header::new(":status", "200"))
+                headers.contains_header(":status", "200")
             )
         )
     };

--- a/neqo-http3/src/headers_checks.rs
+++ b/neqo-http3/src/headers_checks.rs
@@ -5,7 +5,7 @@
 // except according to those terms.
 
 use enumset::{enum_set, EnumSet, EnumSetType};
-use neqo_common::Header;
+use neqo_common::{header::HeadersExt, Header};
 
 use crate::{Error, MessageType, Res};
 
@@ -49,10 +49,9 @@ impl TryFrom<(MessageType, &str)> for PseudoHeaderState {
 /// Returns an error if response headers do not contain
 /// a status header or if the value of the header is 101 or cannot be parsed.
 pub fn is_interim(headers: &[Header]) -> Res<bool> {
-    let status = headers.iter().take(1).find(|h| h.name() == ":status");
-    if let Some(h) = status {
+    if let Some(h) = headers.iter().take(1).find_header(":status") {
         #[allow(clippy::map_err_ignore)]
-        let status_code = h.value().parse::<i32>().map_err(|_| Error::InvalidHeader)?;
+        let status_code = h.value().parse::<u16>().map_err(|_| Error::InvalidHeader)?;
         if status_code == 101 {
             // https://datatracker.ietf.org/doc/html/draft-ietf-quic-http#section-4.3
             Err(Error::InvalidHeader)

--- a/neqo-http3/src/recv_message.rs
+++ b/neqo-http3/src/recv_message.rs
@@ -6,7 +6,7 @@
 
 use std::{cell::RefCell, cmp::min, collections::VecDeque, fmt::Debug, rc::Rc};
 
-use neqo_common::{qdebug, qinfo, qtrace, Header};
+use neqo_common::{header::HeadersExt, qdebug, qinfo, qtrace, Header};
 use neqo_qpack::decoder::QPackDecoder;
 use neqo_transport::{Connection, StreamId};
 
@@ -167,8 +167,8 @@ impl RecvMessage {
         }
 
         let is_web_transport = self.message_type == MessageType::Request
-            && headers.contains(&Header::new(":method", "CONNECT"))
-            && headers.contains(&Header::new(":protocol", "webtransport"));
+            && headers.contains_header(":method", "CONNECT")
+            && headers.contains_header(":protocol", "webtransport");
         if is_web_transport {
             self.conn_events
                 .extended_connect_new_session(self.stream_id, headers);

--- a/neqo-http3/tests/webtransport.rs
+++ b/neqo-http3/tests/webtransport.rs
@@ -6,7 +6,7 @@
 
 use std::{cell::RefCell, rc::Rc};
 
-use neqo_common::{event::Provider, Header};
+use neqo_common::{event::Provider, header::HeadersExt};
 use neqo_crypto::AuthenticationStatus;
 use neqo_http3::{
     Http3Client, Http3ClientEvent, Http3OrWebTransportStream, Http3Parameters, Http3Server,
@@ -96,8 +96,8 @@ fn create_wt_session(client: &mut Http3Client, server: &mut Http3Server) -> WebT
                 headers,
             }) => {
                 assert!(
-                    headers.contains(&Header::new(":method", "CONNECT"))
-                        && headers.contains(&Header::new(":protocol", "webtransport"))
+                    headers.contains_header(":method", "CONNECT")
+                        && headers.contains_header(":protocol", "webtransport")
                 );
                 session
                     .response(&WebTransportSessionAcceptAction::Accept)
@@ -123,7 +123,7 @@ fn create_wt_session(client: &mut Http3Client, server: &mut Http3Server) -> WebT
             }) if (
                 stream_id == wt_session_id &&
                 status == 200 &&
-                headers.contains(&Header::new(":status", "200"))
+                headers.contains_header(":status", "200")
             )
         )
     };


### PR DESCRIPTION
This should reduce the cost of searching headers a little.

@mxinden suggested that we use `Cow` or have some sort of `BorrowedHeader` type, but this is easier to drive.